### PR TITLE
Use string when comparing with info_get

### DIFF
--- a/pushjet.py
+++ b/pushjet.py
@@ -137,7 +137,7 @@ def should_send(buffer, tags, nick, highlighted):
 	elif notify_when == 'detached':
 		# user has opted to only be notified when detached (relays)
 		num_relays = weechat.info_get('relay_client_count', 'connected')
-		if num_relays != 0:
+		if num_relays != '0':
 			# some relay(s) connected, bail
 			return False
 


### PR DESCRIPTION
Currently the "detached" setting for `notify_when` does not detect attached relays, since it compares 0 to '0'. This PR fixes that by using string equality.